### PR TITLE
[16.0][IMP] stock_product_qty_by_packaging: add field in view

### DIFF
--- a/stock_product_qty_by_packaging/views/stock_picking.xml
+++ b/stock_product_qty_by_packaging/views/stock_picking.xml
@@ -5,10 +5,17 @@
         <field name="model">stock.picking</field>
         <field name="inherit_id" ref="stock.view_picking_form" />
         <field name="arch" type="xml">
-            <xpath
-                expr="//field[@name='move_ids_without_package']/tree/field[@name='product_uom']"
-                position="after"
-            >
+            <xpath expr="//field[@name='move_ids_without_package']/tree/field[@name='product_uom']" position="after">
+                <field name="product_qty_by_packaging_display" />
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_stock_move_line_detailed_operation_tree" model="ir.ui.view">
+        <field name="model">stock.move.line</field>
+        <field name="inherit_id" ref="stock.view_stock_move_line_detailed_operation_tree" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='product_uom_id']" position="after">
                 <field name="product_qty_by_packaging_display" />
             </xpath>
         </field>


### PR DESCRIPTION
This pull request includes changes to the `stock_product_qty_by_packaging` module, specifically modifying the view for `stock_move_line` to display the `product_qty_by_packaging_display` field. The changes aim to enhance the user interface by adding this new field to the relevant view.

Enhancements to user interface:

* [`stock_product_qty_by_packaging/views/stock_picking.xml`](diffhunk://#diff-ee2c9e58675cff7f67b15503287e55b3e2daf66ce70fa9a44ff1835458bc774cL8-R18): Added the `product_qty_by_packaging_display` field to the `stock_move_line_detailed_operation_tree` view.